### PR TITLE
Add API to allow for components to be cleaned up

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ manager.resetViews();
 
 ## API
 
-### viewloader.execute(views, scope, includeScope);
+### viewloader(views, scope, includeScope);
 
   * **views**: An `object` of view functions mapped to `data-view-[name]` attributes. (Required)
   * **scope**: An `element` or `nodelist` to scope the view loader to. (Optional. Defaults to `document`)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ A tiny DOM bootstrapper.
 ```js
 // bar-chart.js
 
-module.exports = function myBarChart (el, props) {
+export default function myBarChart (el, props) {
   console.log(el, props); //=> div {data: [1,2,3]}
   return {
-    reset: function() { ... },
-    destroy: function() { ... }
+    reset: () => { ... },
+    destroy: () => { ... }
   }
 };
 ```
@@ -28,22 +28,17 @@ module.exports = function myBarChart (el, props) {
 ```js
 // index.js
 
-var viewloader = require('viewloader');
-var myBarChart = require('./bar-chart');
-var myLineChart = require('./line-chart');
+import viewloader from "viewloader";
+import myBarChart from "./bar-chart";
+import myLineChart from "./line-chart";
 
-var views = {};
-
-views.myBarChart = function(el, props) {
-  return myBarChart(el, props);
-};
-
-views.myLineChart = function(el, props) {
-  return myLineChart(el, props);
+const views = {
+  myBarChart,
+  myLineChart
 };
 
 // Create the instance
-var manager = viewloader(views);
+const manager = viewloader(views);
 // Call the view functions
 manager.callViews();
 // Call the `reset` methods of each view function
@@ -56,8 +51,26 @@ manager.resetViews();
 
 ## API
 
-### viewloader(views, scope, includeScope);
+```
+viewloader(views, scope, includeScope);
+```
 
-  * **views**: An `object` of view functions mapped to `data-view-[name]` attributes. (Required)
-  * **scope**: An `element` or `nodelist` to scope the view loader to. (Optional. Defaults to `document`)
-  * **includeScope**: A `boolean` to indicate if the scoped element should be included in the scoped views. (Optional: Defaults to `false`)
+  * **views** — An `object` of view functions mapped to `data-view-[name]` attributes. (Required)
+  * **scope** — An `element` or `nodelist` to scope the view loader to. (Optional. Defaults to `document`)
+  * **includeScope** — A `boolean` to indicate if the scoped element should be included in the scoped views. (Optional: Defaults to `false`)
+
+## Promises
+
+Viewloader supports view functions that return a `Promise`, automatically setting the resolved return value from any promises once that value is resolved. This means you can call viewloader synchronously with underlying code in your views that is asynchronous:
+
+```js
+import viewloader from "viewloader";
+
+const views = {
+  asyncView: (el, props) => {
+    return import("./async-import")
+      .then((asyncImport) => {
+        return asyncImport(el, props);
+      });
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A tiny DOM bootstrapper.
 
 module.exports = function myBarChart (el, props) {
   console.log(el, props); //=> div {data: [1,2,3]}
+  return {
+    reset: function() { ... },
+    destroy: function() { ... }
+  }
 };
 ```
 
@@ -31,17 +35,24 @@ var myLineChart = require('./line-chart');
 var views = {};
 
 views.myBarChart = function(el, props) {
-  myBarChart(el, props);
+  return myBarChart(el, props);
 };
 
 views.myLineChart = function(el, props) {
-  myLineChart(el, props);
+  return myLineChart(el, props);
 };
 
-viewloader.execute(views);
+// Create the instance
+var manager = viewloader(views);
+// Call the view functions
+manager.callViews();
+// Call the `reset` methods of each view function
+manager.resetViews();
+// Call the `destroy` methods of each view function
+manager.resetViews();
 ```
 
-[More examples here](https://github.com/icelab/viewloader/tree/master/examples).
+[More examples here](examples).
 
 ## API
 

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -6,4 +6,4 @@ views.myBarChart = function(el, props) {
   myBarChart(el, props);
 };
 
-viewLoader.execute(views);
+viewLoader(views).callViews();

--- a/examples/scope-exclude/index.js
+++ b/examples/scope-exclude/index.js
@@ -31,4 +31,5 @@ views.articleStats = function (el, props) {
 
 // scope to `data-view-article`, but exclude the scoped element
 var scope = document.querySelector('[data-view-article]');
-viewLoader.execute(views, scope, false);
+var manager = viewLoader(views, scope, false);
+manager.callViews();

--- a/examples/scope-include/index.js
+++ b/examples/scope-include/index.js
@@ -31,4 +31,5 @@ views.articleStats = function (el, props) {
 
 // scope to `data-view-article` and include the scoped element
 var scope = document.querySelector('[data-view-article]');
-viewLoader.execute(views, scope, true);
+var manager = viewLoader(views, scope, true);
+manager.callViews();

--- a/examples/scope-nodelist/index.js
+++ b/examples/scope-nodelist/index.js
@@ -31,4 +31,5 @@ views.articleStats = function (el, props) {
 
 // scope to all `data-view-article`
 var nodeList = document.querySelectorAll('[data-view-article]');
-viewLoader.execute(views, nodeList, true);
+var manager = viewLoader(views, nodeList, true);
+manager.callViews();

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ Viewloader.prototype.callViews = function() {
  */
 Viewloader.prototype.resetViews = function() {
   this.initializedViews.forEach(function(view) {
-    if (view.reset) {
+    if (view != null && view.reset) {
       view.reset();
     }
   });
@@ -173,7 +173,7 @@ Viewloader.prototype.resetViews = function() {
  */
 Viewloader.prototype.destroyViews = function() {
   this.initializedViews.forEach(function(view) {
-    if (view.destroy) {
+    if (view != null && view.destroy) {
       view.destroy();
     }
   });

--- a/index.js
+++ b/index.js
@@ -137,12 +137,20 @@ Viewloader.prototype.callViews = function() {
     }
 
     // for each value in `elements`, call `callViewFunction`
-    this.initializedViews = Array.prototype.map.call(elements, function(
-      element
-    ) {
-      return callViewFunction(_this.views[view], viewAttr, element);
-    });
+    this.initializedViews = this.initializedViews.concat(
+      Array.prototype.map.call(elements, function(element) {
+        return callViewFunction(_this.views[view], viewAttr, element);
+      })
+    );
   }
+  // Resolve any Promises returned from views
+  this.initializedViews.forEach(function(returnValue, i) {
+    if (returnValue && returnValue.then) {
+      returnValue.then(function(r) {
+        _this.initializedViews[i] = r;
+      });
+    }
+  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint": "^1.10.3",
     "faucet": "0.0.1",
     "jsdom": "^3.1.2",
+    "promise-polyfill": "7.0.0",
     "tape": "^4.2.2"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var Promise = require("promise-polyfill");
 var test = require("tape");
 var viewloader = require("../");
 var createEl = require("./fixtures/create-element.js");
@@ -206,6 +207,29 @@ test("should call the view instance methods ...", function(nest) {
     manager.callViews();
     manager.destroyViews();
     assert.ok(manager.initializedViews.length === 0);
+    assert.end();
+  });
+
+  nest.test("... handling returned Promises", function(assert) {
+    createDOM();
+    var el = createEl("data-view-basic", "true", false);
+    document.appendChild(el);
+
+    var views = {};
+    views.basic = function() {
+      var p = new Promise(function(resolve) {
+        resolve({
+          reset: function() {
+            assert.ok(true);
+          }
+        });
+      });
+      return p;
+    };
+
+    var manager = viewloader(views);
+    manager.callViews();
+    manager.resetViews();
     assert.end();
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,21 +1,21 @@
 "use strict";
 
 var test = require("tape");
-var viewLoader = require("../");
+var viewloader = require("../");
 var createEl = require("./fixtures/create-element.js");
 var createNodes = require("./fixtures/create-nodes.js");
 var createDOM = require("./fixtures/create-dom.js");
 
-test("should call function when data-attribute is found and ...", function (nest) {
-  nest.test("... parse JSON", function (assert) {
+test("should call function when data-attribute is found and ...", function(nest) {
+  nest.test("... parse JSON", function(assert) {
     createDOM();
     var el = createEl("data-view-basic", '{"data":[1,2,3]}', false);
     document.appendChild(el);
 
-    function myModuleFunction (el, props) {
-      var expected = {data: [1,2,3]};
+    function myModuleFunction(el, props) {
+      var expected = { data: [1, 2, 3] };
       assert.deepEqual(props, expected);
-      assert.ok(el.textContent = expected);
+      assert.ok((el.textContent = expected));
       assert.end();
     }
 
@@ -24,18 +24,19 @@ test("should call function when data-attribute is found and ...", function (nest
       myModuleFunction(el, props);
     };
 
-    viewLoader.execute(views);
+    var manager = viewloader(views);
+    manager.callViews();
   });
 
-  nest.test("... return String", function (assert) {
+  nest.test("... return String", function(assert) {
     createDOM();
     var el = createEl("data-view-basic", "basic example", false);
     document.appendChild(el);
 
-    function myModuleFunction (el, props) {
+    function myModuleFunction(el, props) {
       var expected = "basic example";
       assert.equal(props, expected);
-      assert.ok(el.textContent = expected);
+      assert.ok((el.textContent = expected));
       assert.end();
     }
 
@@ -44,81 +45,83 @@ test("should call function when data-attribute is found and ...", function (nest
       myModuleFunction(el, props);
     };
 
-    viewLoader.execute(views);
+    var manager = viewloader(views);
+    manager.callViews();
   });
 });
 
-
-test('should target data-attributes with scope and ...', function (nest) {
-  nest.test("... exclude scope element", function (assert) {
+test("should target data-attributes with scope and ...", function(nest) {
+  nest.test("... exclude scope element", function(assert) {
     createDOM();
     var el = createEl("data-view-scoped-exclude", "scoped-exclude", true);
     document.appendChild(el);
 
-    function myParentFunction () {
+    function myParentFunction() {
       assert.ok(false);
     }
 
-    function myChildFunction (el, props) {
+    function myChildFunction(el, props) {
       var expected = "child";
       assert.equal(props, expected);
-      assert.ok(el.textContent = expected);
+      assert.ok((el.textContent = expected));
       assert.end();
     }
 
     var views = {};
-    views.scopedExclude = function (el, props) {
+    views.scopedExclude = function(el, props) {
       myParentFunction(el, props);
     };
 
-    views.child = function (el, props) {
+    views.child = function(el, props) {
       myChildFunction(el, props);
     };
 
-    var scopedElement = document.querySelector('[data-view-scoped-exclude]');
-    viewLoader.execute(views, scopedElement, false);
+    var scopedElement = document.querySelector("[data-view-scoped-exclude]");
+    var manager = viewloader(views, scopedElement, false);
+    manager.callViews();
   });
 
-  nest.test("... include scope element", function (assert) {
+  nest.test("... include scope element", function(assert) {
     createDOM();
     var el = createEl("data-view-scoped-include", "scoped-include", true);
     document.appendChild(el);
 
-    function myParentFunction (el, props) {
+    function myParentFunction(el, props) {
       var expected = "scoped-include";
       assert.equal(props, expected);
-      assert.ok(el.textContent = expected);
+      assert.ok((el.textContent = expected));
     }
 
-    function myChildFunction (el, props) {
+    function myChildFunction(el, props) {
       var expected = "child";
       assert.equal(props, expected);
-      assert.ok(el.textContent = expected);
+      assert.ok((el.textContent = expected));
       assert.end();
     }
 
     var views = {};
-    views.scopedExclude = function (el, props) {
+    views.scopedExclude = function(el, props) {
       myParentFunction(el, props);
     };
 
-    views.child = function (el, props) {
+    views.child = function(el, props) {
       myChildFunction(el, props);
     };
 
-    var scopedElement = document.querySelector('[data-view-scoped-exclude]');
-    viewLoader.execute(views, scopedElement, true);
+    var scopedElement = document.querySelector("[data-view-scoped-exclude]");
+    var manager = viewloader(views, scopedElement, true);
+    manager.callViews();
   });
 });
 
-test("should call function for each data-attribute in nodelist", function (assert) {
+test("should call function for each data-attribute in nodelist", function(assert) {
   createDOM();
   var nodes = createNodes("data-view-scope-nodelist", "scope-nodelist", 3);
   document.appendChild(nodes);
 
   var count = 0;
 
-  function myChildFunction () {
+  function myChildFunction() {
     count++;
   }
 
@@ -127,9 +130,82 @@ test("should call function for each data-attribute in nodelist", function (asser
     myChildFunction(el, props);
   };
 
-  var nodelist = document.querySelectorAll('[data-view-scope-nodelist]');
-  viewLoader.execute(views, nodelist, false);
+  var nodelist = document.querySelectorAll("[data-view-scope-nodelist]");
+  var manager = viewloader(views, nodelist, false);
+  manager.callViews();
 
   assert.equal(count, 3);
   assert.end();
+});
+
+test("should allow the views to be set ...", function(nest) {
+  nest.test("... setupViews", function(assert) {
+    assert.plan(2);
+    createDOM();
+    var basicEl = createEl("data-view-basic", "true", false);
+    var notBasicEl = createEl("data-view-not-basic", "true", false);
+    basicEl.appendChild(notBasicEl);
+    document.appendChild(basicEl);
+
+    var views = {};
+    views.basic = function() {
+      assert.ok(true);
+    };
+
+    var manager = viewloader(views);
+    manager.callViews();
+
+    views = {};
+    views.notBasic = function() {
+      assert.ok(true);
+    };
+
+    manager.setViews(views);
+    manager.callViews();
+
+    assert.end();
+  });
+});
+
+test("should call the view instance methods ...", function(nest) {
+  nest.test("... reset", function(assert) {
+    createDOM();
+    var el = createEl("data-view-basic", "true", false);
+    document.appendChild(el);
+
+    var views = {};
+    views.basic = function() {
+      return {
+        reset: function() {
+          assert.ok(true);
+          assert.end();
+        }
+      };
+    };
+
+    var manager = viewloader(views);
+    manager.callViews();
+    manager.resetViews();
+  });
+
+  nest.test("... destroy", function(assert) {
+    createDOM();
+    var el = createEl("data-view-basic", "true", false);
+    document.appendChild(el);
+
+    var views = {};
+    views.basic = function() {
+      return {
+        destroy: function() {
+          assert.ok(true);
+        }
+      };
+    };
+
+    var manager = viewloader(views);
+    manager.callViews();
+    manager.destroyViews();
+    assert.ok(manager.initializedViews.length === 0);
+    assert.end();
+  });
 });


### PR DESCRIPTION
Viewloader now returns an instance that retains the returned values from each viewloader component function, and a simple convention for calling a couple of methods on those functions:

* `instance.resetViews()` will call the `reset` method of the return value
  from a viewloader component function
* `instance.destroyViews()` will call the `destroy` method of the return
  value from a viewloader component function

A contrived example might look like:

```html
<button data-view-thinger>Click me</button>
```

```js
function thinger(el, props) {
  var cachedInnerHTML = el.innerHTML;
  // Initialisation
  el.textContent = "Clock me";
  el.addEventListener("click", (e) => {
    e.preventDefault();
    console.log(Date.now);
  });
  return {
    reset: () => {
      el.innerHTML = cachedInnerHTML;
      el.removeEventListener("click");
    },
    destroy: () => {
      el.removeEventListener("click");
      el.parentNode.removeChild(el);
    }
  }
}
```

On a page with multiple `thinger` instances, we’d be now able to reset and destroy them as appropriate to the lifecycle of the page.
  